### PR TITLE
Fix flaky test: testWithParam

### DIFF
--- a/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
+++ b/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
@@ -18,8 +18,8 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Sets;
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -37,7 +37,8 @@ public class CasLoginRefUrlEncoderTest {
         encoder.setCasLoginUrl(
                 "https://cas:80/cas/login?service=_CURRENT_SERVER_NAME_/uPortal/Login");
         UrlMultiServerNameCustomizer urlCustomizer = new UrlMultiServerNameCustomizer();
-        urlCustomizer.setAllServerNames(Sets.newLinkedHashSet(Arrays.asList("myhost:8080", "theirhost:8443")));
+        urlCustomizer.setAllServerNames(
+                Sets.newLinkedHashSet(Arrays.asList("myhost:8080", "theirhost:8443")));
         List<IAuthUrlCustomizer> customizers = new ArrayList<>();
         customizers.add(urlCustomizer);
         UrlAuthCustomizerRegistry registry = new UrlAuthCustomizerRegistry();

--- a/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
+++ b/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java
@@ -18,6 +18,7 @@ import static org.junit.Assert.assertEquals;
 
 import com.google.common.collect.Sets;
 import java.io.UnsupportedEncodingException;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import org.junit.Before;
@@ -36,7 +37,7 @@ public class CasLoginRefUrlEncoderTest {
         encoder.setCasLoginUrl(
                 "https://cas:80/cas/login?service=_CURRENT_SERVER_NAME_/uPortal/Login");
         UrlMultiServerNameCustomizer urlCustomizer = new UrlMultiServerNameCustomizer();
-        urlCustomizer.setAllServerNames(Sets.newHashSet("myhost:8080", "theirhost:8443"));
+        urlCustomizer.setAllServerNames(Sets.newLinkedHashSet(Arrays.asList("myhost:8080", "theirhost:8443")));
         List<IAuthUrlCustomizer> customizers = new ArrayList<>();
         customizers.add(urlCustomizer);
         UrlAuthCustomizerRegistry registry = new UrlAuthCustomizerRegistry();

--- a/uPortal-utils/uPortal-utils-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java
+++ b/uPortal-utils/uPortal-utils-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java
@@ -1,6 +1,6 @@
 package org.apereo.portal.url;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
@@ -14,13 +14,13 @@ public class UrlMultiServerNameCustomizer implements IAuthUrlCustomizer {
     /** Logger. */
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
-    private Set<String> allServerNames = new HashSet<>();
+    private Set<String> allServerNames = new LinkedHashSet<>();
 
     private String serverNameTextReplacement = "_CURRENT_SERVER_NAME_";
 
     @Required
     public void setAllServerNames(final Set<String> serverNames) {
-        this.allServerNames = new HashSet<>(serverNames);
+        this.allServerNames = new LinkedHashSet<>(serverNames);
         Assert.notEmpty(this.allServerNames, "The attribute serverNames should not be empty");
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please review below requirements.

Bug fixes and new features should be reported on the issue tracker: https://github.com/Jasig/uPortal/issues

Contributors guide: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

-   [x] the [individual contributor license agreement][] is signed
-   [x] commit message follows [commit guidelines][]

##### Description of change
<!-- Provide a description of the change below this comment. -->
This PR aims to fix the flaky test: [org.apereo.portal.url.CasLoginRefUrlEncoderTest.testWithParam](https://github.com/KiruthikaJanakiraman/uPortal/blob/23e387d65fd4f740533b1d27d840632724582f43/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java#L62) similar to previously raised PRs: https://github.com/uPortal-Project/uPortal/pull/2718 and https://github.com/uPortal-Project/uPortal/pull/2719

I found and confirmed the flaky behaviour of the tests using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

**Problem**
The test case [org.apereo.portal.url.CasLoginRefUrlEncoderTest.testWithParam](https://github.com/KiruthikaJanakiraman/uPortal/blob/23e387d65fd4f740533b1d27d840632724582f43/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java#L62) fails due to the below assertion:

https://github.com/KiruthikaJanakiraman/uPortal/blob/23e387d65fd4f740533b1d27d840632724582f43/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java#L66-L68

This is because, [findMatchingServerName](https://github.com/KiruthikaJanakiraman/uPortal/blob/5d1d7436a24c3b435e26798f9346ec8c7c539c3a/uPortal-utils/uPortal-utils-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java#L51) returns the first element from `allServerNames` collection.

https://github.com/KiruthikaJanakiraman/uPortal/blob/5d1d7436a24c3b435e26798f9346ec8c7c539c3a/uPortal-utils/uPortal-utils-url/src/main/java/org/apereo/portal/url/UrlMultiServerNameCustomizer.java#L63

Since `allServerNames` is a `HashSet`, the order of the items `"myhost:8080", "theirhost:8443"` in the `HashSet` is not preserved. Hence the server name returned by `findMatchingServerName` varies upon running NonDex causing the test [testWithParam](https://github.com/KiruthikaJanakiraman/uPortal/blob/23e387d65fd4f740533b1d27d840632724582f43/uPortal-security/uPortal-security-mvc/src/test/java/org/apereo/portal/url/CasLoginRefUrlEncoderTest.java#L62) to fail.

**Solution**
This PR fixes the flakiness by using a `LinkedHashSet` to store `allServerNames` since `LinkedHashSet` preserves the order of the elements.

**Steps to reproduce**
The following command can be used to reproduce the assertion errors and verify the fix.

**Integrate NonDex:**

**Add the following snippet to the top of the build.gradle in $PROJ_DIR:**
```
plugins {
    id 'edu.illinois.nondex' version '2.1.1-1'
}
```

**Append to build.gradle in $PROJ_DIR:**
```
apply plugin: 'edu.illinois.nondex'
```

**Execute Test with Gradle:**
```
./gradlew --info uPortal-webapp:test --tests org.apereo.portal.url.CasLoginRefUrlEncoderTest.testWithParam
```

**Run NonDex:**
```
./gradlew --info uPortal-webapp:nondexTest --tests=org.apereo.portal.url.CasLoginRefUrlEncoderTest.testWithParam --nondexRuns=50 -x autoLintGradle
```

**Test Environment:**
```
Java version "1.8.0_381"
macOS Venture Version 13.4.1 (22F82)
```

Please let me know if you have any concerns or questions.


<!-- Reference Links -->

[individual contributor license agreement]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#individual-contributor-license-agreement
[commit guidelines]: https://github.com/Jasig/uPortal/blob/master/CONTRIBUTING.md#commit
[message properties]: https://github.com/Jasig/uPortal/tree/master/uportal-war/src/main/resources/properties/i18n
[WCAG 2.0 AA]: https://www.w3.org/WAI/WCAG20/quickref/?levels=aaa&technologies=smil%2Cpdf%2Cflash%2Csl